### PR TITLE
chore: bump minimum Node.js to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -44,14 +44,14 @@ jobs:
         run: npm run coverage
 
       - name: Upload coverage to Codecov
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '22.x'
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
 
       - name: Update coverage badge
-        if: matrix.node-version == '20.x' && github.ref == 'refs/heads/main'
+        if: matrix.node-version == '22.x' && github.ref == 'refs/heads/main'
         run: |
           # Install bc calculator
           sudo apt-get update && sudo apt-get install -y bc
@@ -100,7 +100,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "author": "Werner Glinka <werner@glinka.co>",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "src/**/*.js",


### PR DESCRIPTION
## Summary

- Raises `engines.node` from `>=20.0.0` to `>=22.0.0`
- Updates CI matrix from `[20.x, 22.x]` to `[22.x, 24.x]`
- Updates release workflow + integration job to Node 22
- Leaves scaffolded-plugin templates untouched (separate ecosystem-facing change)

## Why

Node 22 promotes built-in test coverage (including LCOV reporter) out of experimental, which unblocks a planned follow-up to migrate from `mocha` + `c8` to `node --test`. Node 20 reaches end-of-life in April 2026, so this is also a natural time to drop it.

## Test plan

- [x] All 147 tests pass on Node 22 locally
- [x] `npm run lint:check` clean
- [x] `npm run format:check` clean
- [ ] CI passes on both 22.x and 24.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)