### PR TITLE
Migrate test runner: mocha + chai + c8 → node:test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ const processFiles = (files, plugins) => {
 
 All contributions must include appropriate tests:
 
-- We use **Mocha** for unit testing
+- We use the **Node.js native test runner** (`node --test`) with `node:assert/strict`
 - Aim for high test coverage
 - Test edge cases and error conditions
 - Keep tests focused and readable
@@ -304,7 +304,7 @@ AI assistance is primarily used for:
 - Generating boilerplate code and repetitive patterns
 - Refactoring existing code to match our functional programming standards
 - Creating comprehensive JSDoc documentation
-- Writing unit tests following our Mocha conventions
+- Writing unit tests using `node --test` and `node:assert`
 - Code reviews and identifying potential improvements
 
 AI is **not** used for:
@@ -321,7 +321,7 @@ All AI-generated code must adhere to our project preferences:
 - **Paradigm**: Functional programming with pure functions and explicit returns
 - **Architecture**: Modular design with dependency injection and separation of concerns
 - **Documentation**: Comprehensive JSDoc comments with descriptive naming
-- **Testing**: Mocha-based unit tests with high coverage
+- **Testing**: `node --test` unit tests with high coverage
 
 ### For Contributors Using AI
 

--- a/README.md
+++ b/README.md
@@ -938,7 +938,7 @@ The MCP server itself uses comprehensive testing:
 npm test
 
 # Run tests with coverage
-npm run test:coverage
+npm run coverage
 
 # Run linting
 npm run lint

--- a/TESTING.md
+++ b/TESTING.md
@@ -424,10 +424,13 @@ For development of the MCP server itself, you can run the unit tests:
 npm test
 
 # Run with coverage
-npm run test:coverage
+npm run coverage
 
-# Run specific test files
-npm test -- --grep "plugin-scaffold"
+# Run a specific test file
+node --test test/plugin-scaffold.test.js
+
+# Filter by test name
+node --test --test-name-pattern="plugin-scaffold" test/*.test.js
 ```
 
-This will run the Mocha test suite and show you detailed test results and coverage information.
+This runs the Node.js native test runner and shows detailed test results and coverage information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metalsmith-plugin-mcp-server",
-  "version": "1.8.2",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metalsmith-plugin-mcp-server",
-      "version": "1.8.2",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -23,11 +23,8 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.12",
         "auto-changelog": "^2.5.0",
-        "c8": "^10.1.3",
-        "chai": "^6.2.2",
         "depcheck": "^1.4.7",
         "metalsmith": "2.6.3",
-        "mocha": "^11.7.5",
         "release-it": "^20.0.0"
       },
       "engines": {
@@ -158,16 +155,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -689,90 +676,6 @@
         }
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1041,24 +944,6 @@
       "funding": {
         "url": "https://github.com/phun-ky/typeof?sponsor=1"
       }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -1416,13 +1301,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -1507,40 +1385,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/c8": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
-      "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.1",
-        "@istanbuljs/schema": "^0.1.3",
-        "find-up": "^5.0.0",
-        "foreground-child": "^3.1.1",
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.1.6",
-        "test-exclude": "^7.0.1",
-        "v8-to-istanbul": "^9.0.0",
-        "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "c8": "bin/c8.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "monocart-coverage-reports": "^2"
-      },
-      "peerDependenciesMeta": {
-        "monocart-coverage-reports": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1600,16 +1444,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1732,77 +1566,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/co": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
@@ -1885,13 +1648,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1980,19 +1736,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/default-browser": {
@@ -2255,16 +1998,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dotenv": {
       "version": "17.2.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
@@ -2291,13 +2024,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -2389,19 +2115,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
@@ -2703,23 +2416,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/findup-sync": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
@@ -2734,33 +2430,6 @@
       },
       "engines": {
         "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/forwarded": {
@@ -3090,16 +2759,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -3124,16 +2783,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -3155,13 +2804,6 @@
       "engines": {
         "node": ">=16.9.0"
       }
-    },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -3470,26 +3112,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3504,19 +3126,6 @@
       "license": "MIT",
       "dependencies": {
         "protocols": "^2.0.1"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-utf8": {
@@ -3573,61 +3182,6 @@
       },
       "engines": {
         "node": "^18.17 || >=20.6.1"
-      }
-    },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -3730,22 +3284,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -3802,40 +3340,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
@@ -3866,22 +3370,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4033,150 +3521,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browser-stdout": "^1.3.1",
-        "chokidar": "^4.0.1",
-        "debug": "^4.3.5",
-        "diff": "^7.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-up": "^5.0.0",
-        "glob": "^10.4.5",
-        "he": "^1.2.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
-        "ms": "^2.1.3",
-        "picocolors": "^1.1.1",
-        "serialize-javascript": "^6.0.2",
-        "strip-json-comments": "^3.1.1",
-        "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
-        "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1",
-        "yargs-unparser": "^2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/mocha/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/mocha/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/ms": {
@@ -4544,38 +3888,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pac-proxy-agent": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
@@ -4612,13 +3924,6 @@
       "peerDependencies": {
         "quickjs-wasi": "^0.0.1"
       }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4706,16 +4011,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -4956,16 +4251,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5198,27 +4483,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5283,16 +4547,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/serve-static": {
@@ -5540,45 +4794,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
@@ -5594,30 +4809,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-bom-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
@@ -5626,32 +4817,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -5665,82 +4830,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/test-exclude": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^10.4.1",
-        "minimatch": "^9.0.4"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tinyexec": {
@@ -5914,21 +5003,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/v8-to-istanbul": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -6033,70 +5107,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/workerpool": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrap-fn": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
@@ -6148,102 +5158,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   },
   "scripts": {
     "start": "node src/index.js",
-    "test": "mocha test/**/*.test.js",
+    "test": "node --test --test-timeout=30000 'test/*.test.js'",
     "test:mcp": "node scripts/test-all.js",
     "test:scaffold": "node scripts/test-scaffold.js",
     "test:validate": "node scripts/test-validate.js",
     "test:configs": "node scripts/test-configs.js",
-    "test:unit": "mocha test/**/*.test.js -t 5000",
-    "coverage": "c8 --include=src/**/*.js --reporter=lcov --reporter=text-summary mocha test/**/*.test.js -t 15000",
+    "test:unit": "node --test --test-timeout=30000 'test/*.test.js'",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info --test-timeout=30000 'test/*.test.js'",
     "format": "biome format --write .",
     "format:check": "biome format .",
     "lint": "biome check --write .",
@@ -64,11 +64,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.12",
     "auto-changelog": "^2.5.0",
-    "c8": "^10.1.3",
-    "chai": "^6.2.2",
     "depcheck": "^1.4.7",
     "metalsmith": "2.6.3",
-    "mocha": "^11.7.5",
     "release-it": "^20.0.0"
   },
   "repository": {

--- a/test/audit-plugin.test.js
+++ b/test/audit-plugin.test.js
@@ -5,7 +5,8 @@
  * attempting to stub ES modules, which is problematic.
  */
 
-import { expect } from 'chai';
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import { auditPlugin } from '../src/tools/audit-plugin.js';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
@@ -84,7 +85,7 @@ console.log('Test file exists');
         output: 'console'
       });
 
-      expect(result).to.be.a('string');
+      assert.equal(typeof result, 'string');
     });
 
     it('should support JSON output format', async () => {
@@ -93,17 +94,17 @@ console.log('Test file exists');
         output: 'json'
       });
 
-      expect(result).to.be.a('string');
+      assert.equal(typeof result, 'string');
 
       const parsed = JSON.parse(result);
-      expect(parsed).to.have.property('pluginName');
-      expect(parsed).to.have.property('results');
-      expect(parsed).to.have.property('overallHealth');
-      expect(parsed.results).to.have.property('validation');
-      expect(parsed.results).to.have.property('linting');
-      expect(parsed.results).to.have.property('formatting');
-      expect(parsed.results).to.have.property('tests');
-      expect(parsed.results).to.have.property('coverage');
+      assert.ok('pluginName' in parsed);
+      assert.ok('results' in parsed);
+      assert.ok('overallHealth' in parsed);
+      assert.ok('validation' in parsed.results);
+      assert.ok('linting' in parsed.results);
+      assert.ok('formatting' in parsed.results);
+      assert.ok('tests' in parsed.results);
+      assert.ok('coverage' in parsed.results);
     });
 
     it('should support markdown output format', async () => {
@@ -112,9 +113,9 @@ console.log('Test file exists');
         output: 'markdown'
       });
 
-      expect(result).to.be.a('string');
-      expect(result).to.include('# Audit Report:');
-      expect(result).to.include('| Check | Status | Details |');
+      assert.equal(typeof result, 'string');
+      assert.ok(result.includes('# Audit Report:'));
+      assert.ok(result.includes('| Check | Status | Details |'));
     });
 
     it('should handle non-existent plugin directory', async () => {
@@ -123,7 +124,7 @@ console.log('Test file exists');
         // If it doesn't throw, that's fine - it should handle gracefully
       } catch (error) {
         // If it does throw, that's also acceptable behavior
-        expect(error).to.be.an('error');
+        assert.ok(error instanceof Error);
       }
     });
 
@@ -134,7 +135,7 @@ console.log('Test file exists');
       });
 
       const parsed = JSON.parse(result);
-      expect(parsed.overallHealth).to.be.oneOf(['EXCELLENT', 'GOOD', 'FAIR', 'NEEDS IMPROVEMENT', 'POOR']);
+      assert.ok(['EXCELLENT', 'GOOD', 'FAIR', 'NEEDS IMPROVEMENT', 'POOR'].includes(parsed.overallHealth));
     });
   });
 
@@ -146,8 +147,8 @@ console.log('Test file exists');
       });
 
       const parsed = JSON.parse(result);
-      expect(parsed.results.validation).to.have.property('score');
-      expect(parsed.results.validation).to.have.property('passed');
+      assert.ok('score' in parsed.results.validation);
+      assert.ok('passed' in parsed.results.validation);
     });
 
     it('should include test results', async () => {
@@ -157,8 +158,8 @@ console.log('Test file exists');
       });
 
       const parsed = JSON.parse(result);
-      expect(parsed.results.tests).to.have.property('passed');
-      expect(parsed.results.tests).to.have.property('stats');
+      assert.ok('passed' in parsed.results.tests);
+      assert.ok('stats' in parsed.results.tests);
     });
 
     it('should include linting and formatting results', async () => {
@@ -168,8 +169,8 @@ console.log('Test file exists');
       });
 
       const parsed = JSON.parse(result);
-      expect(parsed.results.linting).to.have.property('passed');
-      expect(parsed.results.formatting).to.have.property('passed');
+      assert.ok('passed' in parsed.results.linting);
+      assert.ok('passed' in parsed.results.formatting);
     });
   });
 });

--- a/test/generate-configs.test.js
+++ b/test/generate-configs.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,7 +22,7 @@ describe('generate-configs tool', function () {
       outputPath: tmpDir
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     // Check default configs were created
     const expectedFiles = ['eslint.config.js', 'prettier.config.js', '.editorconfig', '.gitignore'];
@@ -32,7 +33,7 @@ describe('generate-configs tool', function () {
         .access(filePath)
         .then(() => true)
         .catch(() => false);
-      expect(exists).to.be.true;
+      assert.equal(exists, true);
     }
   });
 
@@ -42,7 +43,7 @@ describe('generate-configs tool', function () {
       configs: ['eslint', 'release-it']
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     // Check specific configs
     const eslintExists = await fs
@@ -54,15 +55,15 @@ describe('generate-configs tool', function () {
       .then(() => true)
       .catch(() => false);
 
-    expect(eslintExists).to.be.true;
-    expect(releaseItExists).to.be.true;
+    assert.equal(eslintExists, true);
+    assert.equal(releaseItExists, true);
 
     // Check that prettier was not created
     const prettierExists = await fs
       .access(path.join(tmpDir, 'prettier.config.js'))
       .then(() => true)
       .catch(() => false);
-    expect(prettierExists).to.be.false;
+    assert.equal(prettierExists, false);
   });
 
   it('should not overwrite existing files', async function () {
@@ -77,11 +78,11 @@ describe('generate-configs tool', function () {
 
     // Should report error for existing file
     const text = result.content[0].text;
-    expect(text).to.include('already exists');
+    assert.ok(text.includes('already exists'));
 
     // Check file wasn't overwritten
     const content = await fs.readFile(path.join(tmpDir, 'eslint.config.js'), 'utf-8');
-    expect(content).to.equal(existingContent);
+    assert.equal(content, existingContent);
   });
 
   it('should validate ESLint config content', async function () {
@@ -93,10 +94,10 @@ describe('generate-configs tool', function () {
     const content = await fs.readFile(path.join(tmpDir, 'eslint.config.js'), 'utf-8');
 
     // Check for modern flat config structure
-    expect(content).to.include('export default');
-    expect(content).to.include('@eslint/js');
-    expect(content).to.include('languageOptions');
-    expect(content).to.include('ecmaVersion: 2024');
+    assert.ok(content.includes('export default'));
+    assert.ok(content.includes('@eslint/js'));
+    assert.ok(content.includes('languageOptions'));
+    assert.ok(content.includes('ecmaVersion: 2024'));
   });
 
   it('should validate Prettier config content', async function () {
@@ -108,10 +109,10 @@ describe('generate-configs tool', function () {
     const content = await fs.readFile(path.join(tmpDir, 'prettier.config.js'), 'utf-8');
 
     // Check for key prettier options
-    expect(content).to.include('printWidth');
-    expect(content).to.include('singleQuote');
-    expect(content).to.include('trailingComma');
-    expect(content).to.include('endOfLine');
+    assert.ok(content.includes('printWidth'));
+    assert.ok(content.includes('singleQuote'));
+    assert.ok(content.includes('trailingComma'));
+    assert.ok(content.includes('endOfLine'));
   });
 
   it('should handle unknown config types', async function () {
@@ -121,7 +122,7 @@ describe('generate-configs tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('Unknown config type');
+    assert.ok(text.includes('Unknown config type'));
   });
 
   it('should create output directory if it does not exist', async function () {
@@ -132,13 +133,13 @@ describe('generate-configs tool', function () {
       configs: ['gitignore']
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     const gitignoreExists = await fs
       .access(path.join(nestedPath, '.gitignore'))
       .then(() => true)
       .catch(() => false);
-    expect(gitignoreExists).to.be.true;
+    assert.equal(gitignoreExists, true);
   });
 
   it('should handle mix of valid and invalid config types', async function () {
@@ -148,11 +149,11 @@ describe('generate-configs tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('Generated files:');
-    expect(text).to.include('eslint.config.js');
-    expect(text).to.include('prettier.config.js');
-    expect(text).to.include('Errors:');
-    expect(text).to.include('Unknown config type: invalid-config');
+    assert.ok(text.includes('Generated files:'));
+    assert.ok(text.includes('eslint.config.js'));
+    assert.ok(text.includes('prettier.config.js'));
+    assert.ok(text.includes('Errors:'));
+    assert.ok(text.includes('Unknown config type: invalid-config'));
   });
 
   it('should generate all available config types', async function () {
@@ -161,7 +162,7 @@ describe('generate-configs tool', function () {
       configs: ['eslint', 'prettier', 'editorconfig', 'gitignore', 'release-it']
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     const expectedFiles = ['eslint.config.js', 'prettier.config.js', '.editorconfig', '.gitignore', '.release-it.json'];
 
@@ -170,7 +171,7 @@ describe('generate-configs tool', function () {
         .access(path.join(tmpDir, file))
         .then(() => true)
         .catch(() => false);
-      expect(exists).to.be.true;
+      assert.equal(exists, true);
     }
   });
 
@@ -187,7 +188,7 @@ describe('generate-configs tool', function () {
 
     // Should handle the error gracefully
     const text = result.content[0].text;
-    expect(text).to.include('Failed to generate eslint');
+    assert.ok(text.includes('Failed to generate eslint'));
 
     // Restore permissions for cleanup
     await fs.chmod(readOnlyPath, 0o755);
@@ -199,7 +200,7 @@ describe('generate-configs tool', function () {
       configs: ['release-it']
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     // Check release-it config content
     const releaseItPath = path.join(tmpDir, '.release-it.json');
@@ -207,8 +208,8 @@ describe('generate-configs tool', function () {
     const releaseItConfig = JSON.parse(releaseItContent);
 
     // Should use GitHub's auto-generated release notes
-    expect(releaseItConfig.github.autoGenerate).to.be.true;
-    expect(releaseItConfig.npm.publish).to.be.false;
-    expect(releaseItConfig.github.releaseNotes).to.be.undefined;
+    assert.equal(releaseItConfig.github.autoGenerate, true);
+    assert.equal(releaseItConfig.npm.publish, false);
+    assert.equal(releaseItConfig.github.releaseNotes, undefined);
   });
 });

--- a/test/install-claude-md.test.js
+++ b/test/install-claude-md.test.js
@@ -1,5 +1,5 @@
-import { describe, it, before, after } from 'mocha';
-import { expect } from 'chai';
+import { strict as assert } from 'node:assert';
+import { describe, it, before, after } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import fs from 'node:fs/promises';
@@ -99,15 +99,15 @@ This plugin creates blog pagination metadata.`;
     const result = smartMergeClaudeMd(existingContent, templateContent, { hasMcpSection: false });
 
     // Verify the MCP section was added
-    expect(result).to.include('## MCP Server Integration (CRITICAL)');
-    expect(result).to.include('### Essential MCP Commands');
-    expect(result).to.include('### CRITICAL RULES for AI Assistants');
-    expect(result).to.include('list-templates');
+    assert.ok(result.includes('## MCP Server Integration (CRITICAL)'));
+    assert.ok(result.includes('### Essential MCP Commands'));
+    assert.ok(result.includes('### CRITICAL RULES for AI Assistants'));
+    assert.ok(result.includes('list-templates'));
 
     // Verify existing content is preserved
-    expect(result).to.include('Metalsmith Sectioned Blog Pagination - Development Guide');
-    expect(result).to.include('This plugin generates paginated blog landing pages');
-    expect(result).to.include('## Plugin Overview');
+    assert.ok(result.includes('Metalsmith Sectioned Blog Pagination - Development Guide'));
+    assert.ok(result.includes('This plugin generates paginated blog landing pages'));
+    assert.ok(result.includes('## Plugin Overview'));
   });
 
   it('should update existing MCP section correctly', function () {
@@ -142,14 +142,14 @@ My quick commands.`;
     const result = smartMergeClaudeMd(existingContent, templateContent, { hasMcpSection: true });
 
     // Verify MCP section was replaced with new content
-    expect(result).to.include('**IMPORTANT**: Updated MCP content');
-    expect(result).to.include('### Essential MCP Commands');
-    expect(result).to.include('New commands here');
-    expect(result).to.not.include('Old MCP content');
+    assert.ok(result.includes('**IMPORTANT**: Updated MCP content'));
+    assert.ok(result.includes('### Essential MCP Commands'));
+    assert.ok(result.includes('New commands here'));
+    assert.ok(!result.includes('Old MCP content'));
 
     // Verify other sections are preserved
-    expect(result).to.include('## Quick Commands');
-    expect(result).to.include('My quick commands');
+    assert.ok(result.includes('## Quick Commands'));
+    assert.ok(result.includes('My quick commands'));
   });
 
   it('should handle complete MCP section with all subsections', function () {
@@ -210,15 +210,15 @@ This plugin creates blog pagination metadata that works with sectioned/modular p
     const result = smartMergeClaudeMd(beforeContent, templateContent, { hasMcpSection: false });
 
     // The entire MCP section should be present
-    expect(result).to.include('## MCP Server Integration (CRITICAL)');
-    expect(result).to.include('### Essential MCP Commands');
-    expect(result).to.include('list-templates');
-    expect(result).to.include('get-template plugin/CLAUDE.md');
-    expect(result).to.include('### CRITICAL RULES for AI Assistants');
-    expect(result).to.include('**ALWAYS use MCP server templates verbatim**');
+    assert.ok(result.includes('## MCP Server Integration (CRITICAL)'));
+    assert.ok(result.includes('### Essential MCP Commands'));
+    assert.ok(result.includes('list-templates'));
+    assert.ok(result.includes('get-template plugin/CLAUDE.md'));
+    assert.ok(result.includes('### CRITICAL RULES for AI Assistants'));
+    assert.ok(result.includes('**ALWAYS use MCP server templates verbatim**'));
 
     // Original content should still be there
-    expect(result).to.include('Metalsmith Sectioned Blog Pagination - Development Guide');
-    expect(result).to.include('npm test           # Run all tests');
+    assert.ok(result.includes('Metalsmith Sectioned Blog Pagination - Development Guide'));
+    assert.ok(result.includes('npm test           # Run all tests'));
   });
 });

--- a/test/path-security.test.js
+++ b/test/path-security.test.js
@@ -2,7 +2,8 @@
  * Tests for path security utilities
  */
 
-import { expect } from 'chai';
+import { strict as assert } from 'node:assert';
+import { describe, it, before, after } from 'node:test';
 import path from 'node:path';
 import os from 'node:os';
 import { sanitizePath, sanitizeTemplateName, validatePath, createPathResolver } from '../src/utils/path-security.js';
@@ -14,102 +15,135 @@ describe('Path Security Utilities', () => {
   describe('sanitizePath', () => {
     it('should allow valid relative paths', () => {
       const result = sanitizePath('subdir/file.js', testBase);
-      expect(result).to.equal(path.resolve(testBase, 'subdir/file.js'));
+      assert.equal(result, path.resolve(testBase, 'subdir/file.js'));
     });
 
     it('should allow valid absolute paths without traversal', () => {
       const validPath = '/usr/local/lib/node_modules';
       const result = sanitizePath(validPath, testBase);
-      expect(result).to.equal(path.normalize(validPath));
+      assert.equal(result, path.normalize(validPath));
     });
 
     it('should allow current directory reference', () => {
       const result = sanitizePath('.', testBase);
-      expect(result).to.equal(path.resolve(testBase));
+      assert.equal(result, path.resolve(testBase));
     });
 
     it('should allow simple filenames', () => {
       const result = sanitizePath('file.txt', testBase);
-      expect(result).to.equal(path.resolve(testBase, 'file.txt'));
+      assert.equal(result, path.resolve(testBase, 'file.txt'));
     });
 
     it('should prevent relative path traversal with ../', () => {
-      expect(() => sanitizePath('../../../etc/passwd', testBase)).to.throw('Path traversal attempt detected');
+      assert.throws(
+        () => sanitizePath('../../../etc/passwd', testBase),
+        new RegExp('Path traversal attempt detected'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
     });
 
     it('should prevent relative path traversal with ..\\', () => {
-      expect(() => sanitizePath('..\\\\..\\\\..\\\\etc\\\\passwd', testBase)).to.throw(
-        'Path traversal attempt detected'
+      assert.throws(
+        () => sanitizePath('..\\\\..\\\\..\\\\etc\\\\passwd', testBase),
+        new RegExp('Path traversal attempt detected'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
       );
     });
 
     it('should prevent absolute path with traversal patterns', () => {
-      expect(() => sanitizePath('/usr/local/../../../etc/passwd', testBase)).to.throw(
-        'Path traversal attempt detected'
+      assert.throws(
+        () => sanitizePath('/usr/local/../../../etc/passwd', testBase),
+        new RegExp('Path traversal attempt detected'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
       );
     });
 
     it('should prevent Windows-style traversal', () => {
-      expect(() => sanitizePath('C:\\\\..\\\\..\\\\Windows\\\\System32', testBase)).to.throw(
-        'Path traversal attempt detected'
+      assert.throws(
+        () => sanitizePath('C:\\\\..\\\\..\\\\Windows\\\\System32', testBase),
+        new RegExp('Path traversal attempt detected'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
       );
     });
 
     it('should reject invalid input types', () => {
-      expect(() => sanitizePath(null, testBase)).to.throw('Invalid path provided');
-      expect(() => sanitizePath(undefined, testBase)).to.throw('Invalid path provided');
-      expect(() => sanitizePath(123, testBase)).to.throw('Invalid path provided');
+      assert.throws(
+        () => sanitizePath(null, testBase),
+        new RegExp('Invalid path provided'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
+      assert.throws(
+        () => sanitizePath(undefined, testBase),
+        new RegExp('Invalid path provided'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
+      assert.throws(
+        () => sanitizePath(123, testBase),
+        new RegExp('Invalid path provided'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
     });
 
     it('should handle empty string', () => {
-      expect(() => sanitizePath('', testBase)).to.throw('Invalid path provided');
+      assert.throws(
+        () => sanitizePath('', testBase),
+        new RegExp('Invalid path provided'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
     });
 
     it('should normalize paths correctly', () => {
       const result = sanitizePath('subdir//file.js', testBase);
-      expect(result).to.equal(path.resolve(testBase, 'subdir/file.js'));
+      assert.equal(result, path.resolve(testBase, 'subdir/file.js'));
     });
 
     it('should handle temp directory paths used in tests', () => {
       const tempPath = path.join(os.tmpdir(), 'test-plugin');
       const result = sanitizePath(tempPath, testBase);
-      expect(result).to.equal(path.normalize(tempPath));
+      assert.equal(result, path.normalize(tempPath));
     });
   });
 
   describe('sanitizeTemplateName', () => {
     it('should allow valid template names', () => {
-      expect(sanitizeTemplateName('plugin/index')).to.equal('plugin/index');
-      expect(sanitizeTemplateName('configs/eslint')).to.equal('configs/eslint');
+      assert.equal(sanitizeTemplateName('plugin/index'), 'plugin/index');
+      assert.equal(sanitizeTemplateName('configs/eslint'), 'configs/eslint');
     });
 
     it('should remove path traversal attempts', () => {
-      expect(sanitizeTemplateName('../../../etc/passwd')).to.equal('etc/passwd');
-      expect(sanitizeTemplateName('../../template')).to.equal('template');
+      assert.equal(sanitizeTemplateName('../../../etc/passwd'), 'etc/passwd');
+      assert.equal(sanitizeTemplateName('../../template'), 'template');
     });
 
     it('should remove leading slashes', () => {
-      expect(sanitizeTemplateName('/absolute/path')).to.equal('absolute/path');
-      expect(sanitizeTemplateName('\\windows\\path')).to.equal('windows/path');
+      assert.equal(sanitizeTemplateName('/absolute/path'), 'absolute/path');
+      assert.equal(sanitizeTemplateName('\\windows\\path'), 'windows/path');
     });
 
     it('should normalize path separators', () => {
-      expect(sanitizeTemplateName('folder\\\\file')).to.equal('folder/file');
-      expect(sanitizeTemplateName('folder//file')).to.equal('folder/file');
+      assert.equal(sanitizeTemplateName('folder\\\\file'), 'folder/file');
+      assert.equal(sanitizeTemplateName('folder//file'), 'folder/file');
     });
 
     it('should reject null bytes', () => {
-      expect(() => sanitizeTemplateName('file\x00name')).to.throw('Invalid template name: contains null bytes');
+      assert.throws(
+        () => sanitizeTemplateName('file\x00name'),
+        new RegExp('Invalid template name: contains null bytes'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
     });
 
     it('should reject invalid input types', () => {
-      expect(() => sanitizeTemplateName(null)).to.throw('Invalid template name provided');
-      expect(() => sanitizeTemplateName(undefined)).to.throw('Invalid template name provided');
-      expect(() => sanitizeTemplateName(123)).to.throw('Invalid template name provided');
+      assert.throws(
+        () => sanitizeTemplateName(null),
+        new RegExp('Invalid template name provided'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
+      assert.throws(
+        () => sanitizeTemplateName(undefined),
+        new RegExp('Invalid template name provided'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
+      assert.throws(
+        () => sanitizeTemplateName(123),
+        new RegExp('Invalid template name provided'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
     });
 
     it('should handle empty string', () => {
-      expect(() => sanitizeTemplateName('')).to.throw('Invalid template name provided');
+      assert.throws(
+        () => sanitizeTemplateName(''),
+        new RegExp('Invalid template name provided'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
     });
   });
 
@@ -128,24 +162,24 @@ describe('Path Security Utilities', () => {
 
     it('should validate existing paths', async () => {
       const result = await validatePath('test.txt', tempDir);
-      expect(result).to.equal(path.join(tempDir, 'test.txt'));
+      assert.equal(result, path.join(tempDir, 'test.txt'));
     });
 
     it('should reject non-existent paths', async () => {
       try {
         await validatePath('nonexistent.txt', tempDir);
-        expect.fail('Should have thrown an error');
+        assert.fail('Should have thrown an error');
       } catch (error) {
-        expect(error.message).to.include('Path does not exist');
+        assert.ok(error.message.includes('Path does not exist'));
       }
     });
 
     it('should prevent traversal in validation', async () => {
       try {
         await validatePath('../../../etc/passwd', tempDir);
-        expect.fail('Should have thrown an error');
+        assert.fail('Should have thrown an error');
       } catch (error) {
-        expect(error.message).to.include('Path traversal attempt detected');
+        assert.ok(error.message.includes('Path traversal attempt detected'));
       }
     });
   });
@@ -153,18 +187,21 @@ describe('Path Security Utilities', () => {
   describe('createPathResolver', () => {
     it('should create a resolver with the correct base path', () => {
       const resolver = createPathResolver('/base/path');
-      expect(resolver.getBase()).to.equal(path.resolve('/base/path'));
+      assert.equal(resolver.getBase(), path.resolve('/base/path'));
     });
 
     it('should resolve paths relative to base', () => {
       const resolver = createPathResolver('/base/path');
       const resolved = resolver.resolve('subdir/file.js');
-      expect(resolved).to.equal(path.resolve('/base/path', 'subdir/file.js'));
+      assert.equal(resolved, path.resolve('/base/path', 'subdir/file.js'));
     });
 
     it('should prevent traversal through resolver', () => {
       const resolver = createPathResolver('/base/path');
-      expect(() => resolver.resolve('../../../etc/passwd')).to.throw('Path traversal attempt detected');
+      assert.throws(
+        () => resolver.resolve('../../../etc/passwd'),
+        new RegExp('Path traversal attempt detected'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
     });
 
     it('should validate paths through resolver', async () => {
@@ -175,13 +212,13 @@ describe('Path Security Utilities', () => {
       const resolver = createPathResolver(tempDir);
 
       const validPath = await resolver.validate('exists.txt');
-      expect(validPath).to.equal(path.join(tempDir, 'exists.txt'));
+      assert.equal(validPath, path.join(tempDir, 'exists.txt'));
 
       try {
         await resolver.validate('notfound.txt');
-        expect.fail('Should have thrown an error');
+        assert.fail('Should have thrown an error');
       } catch (error) {
-        expect(error.message).to.include('Path does not exist');
+        assert.ok(error.message.includes('Path does not exist'));
       }
 
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/test/plugin-scaffold.test.js
+++ b/test/plugin-scaffold.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -24,8 +25,8 @@ describe('plugin-scaffold tool', function () {
       outputPath: tmpDir
     });
 
-    expect(result.isError).to.be.true;
-    expect(result.content[0].text).to.include('Plugin description is required');
+    assert.equal(result.isError, true);
+    assert.ok(result.content[0].text.includes('Plugin description is required'));
   });
 
   it('should create plugin structure', async function () {
@@ -37,12 +38,12 @@ describe('plugin-scaffold tool', function () {
       outputPath: tmpDir
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     // Check directory structure
     const pluginPath = path.join(tmpDir, pluginName);
     const stats = await fs.stat(pluginPath);
-    expect(stats.isDirectory()).to.be.true;
+    assert.equal(stats.isDirectory(), true);
 
     // Check required files
     const requiredFiles = [
@@ -63,7 +64,7 @@ describe('plugin-scaffold tool', function () {
         .access(filePath)
         .then(() => true)
         .catch(() => false);
-      expect(exists).to.be.true;
+      assert.equal(exists, true);
     }
   });
 
@@ -79,8 +80,8 @@ describe('plugin-scaffold tool', function () {
       outputPath: tmpDir
     });
 
-    expect(result.isError).to.be.true;
-    expect(result.content[0].text).to.include('Plugin description is required');
+    assert.equal(result.isError, true);
+    assert.ok(result.content[0].text.includes('Plugin description is required'));
   });
 
   it('should create basic plugin structure without types', async function () {
@@ -92,7 +93,7 @@ describe('plugin-scaffold tool', function () {
       outputPath: tmpDir
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     // Check basic directory structure exists
     const pluginPath = path.join(tmpDir, pluginName);
@@ -108,8 +109,8 @@ describe('plugin-scaffold tool', function () {
       .then(() => true)
       .catch(() => false);
 
-    expect(srcExists).to.be.true;
-    expect(testExists).to.be.true;
+    assert.equal(srcExists, true);
+    assert.equal(testExists, true);
   });
 
   it('should handle additional features', async function () {
@@ -123,7 +124,7 @@ describe('plugin-scaffold tool', function () {
       outputPath: tmpDir
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     // Check feature-specific directories
     const pluginPath = path.join(tmpDir, pluginName);
@@ -134,7 +135,7 @@ describe('plugin-scaffold tool', function () {
       .access(asyncDir)
       .then(() => true)
       .catch(() => false);
-    expect(hasAsync).to.be.true;
+    assert.equal(hasAsync, true);
 
     // Background processing adds workers
     const workersDir = path.join(pluginPath, 'src', 'workers');
@@ -142,7 +143,7 @@ describe('plugin-scaffold tool', function () {
       .access(workersDir)
       .then(() => true)
       .catch(() => false);
-    expect(hasWorkers).to.be.true;
+    assert.equal(hasWorkers, true);
 
     // Metadata generation adds metadata
     const metadataDir = path.join(pluginPath, 'src', 'metadata');
@@ -150,7 +151,7 @@ describe('plugin-scaffold tool', function () {
       .access(metadataDir)
       .then(() => true)
       .catch(() => false);
-    expect(hasMetadata).to.be.true;
+    assert.equal(hasMetadata, true);
   });
 
   it('should handle template rendering errors gracefully', async function () {
@@ -177,8 +178,8 @@ describe('plugin-scaffold tool', function () {
     // Restore original function
     fs.writeFile = originalWriteFile;
 
-    expect(result.isError).to.be.true;
-    expect(result.content[0].text).to.include('Plugin description is required');
+    assert.equal(result.isError, true);
+    assert.ok(result.content[0].text.includes('Plugin description is required'));
 
     // Verify cleanup happened - directory should not exist
     const pluginPath = path.join(tmpDir, pluginName);
@@ -186,7 +187,7 @@ describe('plugin-scaffold tool', function () {
       .access(pluginPath)
       .then(() => true)
       .catch(() => false);
-    expect(exists).to.be.false;
+    assert.equal(exists, false);
   });
 
   it('should handle git initialization failure gracefully', async function () {
@@ -201,15 +202,15 @@ describe('plugin-scaffold tool', function () {
     });
 
     // Plugin should still be created successfully even if git fails
-    expect(result.isError).to.not.be.true;
-    expect(result.content[0].text).to.include('Successfully created');
+    assert.notEqual(result.isError, true);
+    assert.ok(result.content[0].text.includes('Successfully created'));
 
     const pluginPath = path.join(tmpDir, pluginName);
     const exists = await fs
       .access(pluginPath)
       .then(() => true)
       .catch(() => false);
-    expect(exists).to.be.true;
+    assert.equal(exists, true);
   });
 
   it('should create feature-specific directories when requested', async function () {
@@ -221,7 +222,7 @@ describe('plugin-scaffold tool', function () {
       outputPath: tmpDir
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     // Check if feature-specific directories were created
     const pluginPath = path.join(tmpDir, pluginName);
@@ -237,8 +238,8 @@ describe('plugin-scaffold tool', function () {
       .then(() => true)
       .catch(() => false);
 
-    expect(processorsExists).to.be.true;
-    expect(workersExists).to.be.true;
+    assert.equal(processorsExists, true);
+    assert.equal(workersExists, true);
   });
 
   it('should handle missing template files gracefully', async function () {
@@ -257,8 +258,8 @@ describe('plugin-scaffold tool', function () {
         outputPath: tmpDir
       });
 
-      expect(result.isError).to.be.true;
-      expect(result.content[0].text).to.include('Plugin description is required');
+      assert.equal(result.isError, true);
+      assert.ok(result.content[0].text.includes('Plugin description is required'));
     } finally {
       // Restore the template file
       try {
@@ -278,7 +279,7 @@ describe('plugin-scaffold tool', function () {
       outputPath: tmpDir
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
 
     const pluginPath = path.join(tmpDir, pluginName);
 
@@ -287,12 +288,12 @@ describe('plugin-scaffold tool', function () {
     const releaseStats = await fs.stat(releaseScript);
 
     // Check executable permissions (0o111 = executable by user, group, other)
-    expect(releaseStats.mode & 0o111).to.be.greaterThan(0);
+    assert.ok(releaseStats.mode & (0o111 > 0));
 
     // Check script content contains expected patterns
     const releaseContent = await fs.readFile(releaseScript, 'utf-8');
-    expect(releaseContent).to.include('#!/bin/bash');
-    expect(releaseContent).to.include('gh auth status');
-    expect(releaseContent).to.include('GH_TOKEN');
+    assert.ok(releaseContent.includes('#!/bin/bash'));
+    assert.ok(releaseContent.includes('gh auth status'));
+    assert.ok(releaseContent.includes('GH_TOKEN'));
   });
 });

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
 import { renderTemplate, renderConditionals, render } from '../src/utils/render.js';
 
 describe('render utilities', function () {
@@ -7,56 +8,56 @@ describe('render utilities', function () {
       const template = 'Hello {{ name }}!';
       const data = { name: 'World' };
       const result = renderTemplate(template, data);
-      expect(result).to.equal('Hello World!');
+      assert.equal(result, 'Hello World!');
     });
 
     it('should handle boolean values', function () {
       const template = 'Enabled: {{ enabled }}';
       const data = { enabled: true };
       const result = renderTemplate(template, data);
-      expect(result).to.equal('Enabled: true');
+      assert.equal(result, 'Enabled: true');
     });
 
     it('should handle false boolean values', function () {
       const template = 'Enabled: {{ enabled }}';
       const data = { enabled: false };
       const result = renderTemplate(template, data);
-      expect(result).to.equal('Enabled: false');
+      assert.equal(result, 'Enabled: false');
     });
 
     it('should handle array values', function () {
       const template = 'Items: {{ items }}';
       const data = { items: ['a', 'b', 'c'] };
       const result = renderTemplate(template, data);
-      expect(result).to.equal('Items: a,b,c');
+      assert.equal(result, 'Items: a,b,c');
     });
 
     it('should handle empty arrays', function () {
       const template = 'Items: {{ items }}';
       const data = { items: [] };
       const result = renderTemplate(template, data);
-      expect(result).to.equal('Items: ');
+      assert.equal(result, 'Items: ');
     });
 
     it('should leave unknown variables as empty string', function () {
       const template = 'Hello {{ name }}, age {{ age }}!';
       const data = { name: 'John' };
       const result = renderTemplate(template, data);
-      expect(result).to.equal('Hello John, age !');
+      assert.equal(result, 'Hello John, age !');
     });
 
     it('should handle numbers', function () {
       const template = 'Count: {{ count }}';
       const data = { count: 42 };
       const result = renderTemplate(template, data);
-      expect(result).to.equal('Count: 42');
+      assert.equal(result, 'Count: 42');
     });
 
     it('should handle multiple occurrences of same variable', function () {
       const template = '{{ name }} says hello to {{ name }}';
       const data = { name: 'Alice' };
       const result = renderTemplate(template, data);
-      expect(result).to.equal('Alice says hello to Alice');
+      assert.equal(result, 'Alice says hello to Alice');
     });
   });
 
@@ -65,21 +66,21 @@ describe('render utilities', function () {
       const template = '{% if enabled %}Feature is enabled{% endif %}';
       const data = { enabled: true };
       const result = renderConditionals(template, data);
-      expect(result).to.equal('Feature is enabled');
+      assert.equal(result, 'Feature is enabled');
     });
 
     it('should exclude content when condition is false', function () {
       const template = '{% if enabled %}Feature is enabled{% endif %}';
       const data = { enabled: false };
       const result = renderConditionals(template, data);
-      expect(result).to.equal('');
+      assert.equal(result, '');
     });
 
     it('should exclude content when condition is undefined', function () {
       const template = '{% if enabled %}Feature is enabled{% endif %}';
       const data = {};
       const result = renderConditionals(template, data);
-      expect(result).to.equal('');
+      assert.equal(result, '');
     });
 
     it('should handle multiline conditional content', function () {
@@ -90,15 +91,15 @@ function feature() {
 }{% endif %}`;
       const data = { hasFeature: true };
       const result = renderConditionals(template, data);
-      expect(result).to.include('Feature code here');
-      expect(result).to.include('function feature()');
+      assert.ok(result.includes('Feature code here'));
+      assert.ok(result.includes('function feature()'));
     });
 
     it('should handle multiple conditionals', function () {
       const template = '{% if a %}A{% endif %}{% if b %}B{% endif %}{% if c %}C{% endif %}';
       const data = { a: true, b: false, c: true };
       const result = renderConditionals(template, data);
-      expect(result).to.equal('AC');
+      assert.equal(result, 'AC');
     });
 
     it('should handle nested content with variables', function () {
@@ -106,25 +107,25 @@ function feature() {
       const data = { enabled: true, name: 'World' };
       const result = renderConditionals(template, data);
       // Nunjucks processes everything, including nested variables
-      expect(result).to.equal('Hello World!');
+      assert.equal(result, 'Hello World!');
     });
 
     it('should handle truthy values', function () {
       const template = '{% if value %}Has value{% endif %}';
 
-      expect(renderConditionals(template, { value: 'string' })).to.equal('Has value');
-      expect(renderConditionals(template, { value: 1 })).to.equal('Has value');
+      assert.equal(renderConditionals(template, { value: 'string' }), 'Has value');
+      assert.equal(renderConditionals(template, { value: 1 }), 'Has value');
       // Nunjucks considers empty arrays as truthy (different from Handlebars)
-      expect(renderConditionals(template, { value: [] })).to.equal('Has value');
-      expect(renderConditionals(template, { value: {} })).to.equal('Has value');
+      assert.equal(renderConditionals(template, { value: [] }), 'Has value');
+      assert.equal(renderConditionals(template, { value: {} }), 'Has value');
     });
 
     it('should handle falsy values', function () {
       const template = '{% if value %}Has value{% endif %}';
 
-      expect(renderConditionals(template, { value: '' })).to.equal('');
-      expect(renderConditionals(template, { value: 0 })).to.equal('');
-      expect(renderConditionals(template, { value: null })).to.equal('');
+      assert.equal(renderConditionals(template, { value: '' }), '');
+      assert.equal(renderConditionals(template, { value: 0 }), '');
+      assert.equal(renderConditionals(template, { value: null }), '');
     });
   });
 
@@ -133,14 +134,14 @@ function feature() {
       const template = '{% if enabled %}Hello {{ name }}!{% endif %}';
       const data = { enabled: true, name: 'World' };
       const result = render(template, data);
-      expect(result).to.equal('Hello World!');
+      assert.equal(result, 'Hello World!');
     });
 
     it('should process conditionals before variables', function () {
       const template = '{% if show %}Value: {{ value }}{% endif %}';
       const data = { show: true, value: 42 };
       const result = render(template, data);
-      expect(result).to.equal('Value: 42');
+      assert.equal(result, 'Value: 42');
     });
 
     it('should handle complex template with both features', function () {
@@ -161,47 +162,47 @@ const config = {
       };
 
       const result = render(template, data);
-      expect(result).to.include('name: "test-plugin"');
-      expect(result).to.include('debug: true');
-      expect(result).to.include('features: a,b');
+      assert.ok(result.includes('name: "test-plugin"'));
+      assert.ok(result.includes('debug: true'));
+      assert.ok(result.includes('features: a,b'));
     });
 
     it('should handle empty data object', function () {
       const template = 'Hello {{ name }}! {% if enabled %}Enabled{% endif %}';
       const result = render(template, {});
-      expect(result).to.equal('Hello ! ');
+      assert.equal(result, 'Hello ! ');
     });
 
     it('should handle template with no placeholders', function () {
       const template = 'This is a plain template with no variables.';
       const result = render(template, { unused: 'value' });
-      expect(result).to.equal('This is a plain template with no variables.');
+      assert.equal(result, 'This is a plain template with no variables.');
     });
 
     it('should handle array using join filter', function () {
       const template = "Items: {{ items | join(', ') }}";
       const data = { items: ['a', 'b', 'c'] };
       const result = render(template, data);
-      expect(result).to.equal('Items: a, b, c');
+      assert.equal(result, 'Items: a, b, c');
     });
 
     it('should handle custom filters', function () {
       const template = "{{ 'metalsmith-test' | camelCase }}";
       const result = render(template, {});
-      expect(result).to.equal('metalsmithTest');
+      assert.equal(result, 'metalsmithTest');
     });
 
     it('should handle removePrefix filter', function () {
       const template = "{{ 'metalsmith-plugin' | removePrefix('metalsmith-') }}";
       const result = render(template, {});
-      expect(result).to.equal('plugin');
+      assert.equal(result, 'plugin');
     });
 
     it('should handle for loops', function () {
       const template = '{% for item in items %}{{ item }}{% if not loop.last %}, {% endif %}{% endfor %}';
       const data = { items: ['a', 'b', 'c'] };
       const result = render(template, data);
-      expect(result).to.equal('a, b, c');
+      assert.equal(result, 'a, b, c');
     });
   });
 });

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,7 +28,7 @@ describe('template utilities', function () {
       await copyTemplate(templatePath, targetPath, data);
 
       const result = await fs.readFile(targetPath, 'utf-8');
-      expect(result).to.equal('const name = "test-plugin";');
+      assert.equal(result, 'const name = "test-plugin";');
     });
 
     it('should create target directory if it does not exist', async function () {
@@ -42,7 +43,7 @@ describe('template utilities', function () {
         .access(targetPath)
         .then(() => true)
         .catch(() => false);
-      expect(exists).to.be.true;
+      assert.equal(exists, true);
     });
 
     it('should handle templates with conditionals', async function () {
@@ -61,7 +62,7 @@ const config = {
       await copyTemplate(templatePath, targetPath, data);
 
       const result = await fs.readFile(targetPath, 'utf-8');
-      expect(result).to.include('feature: true');
+      assert.ok(result.includes('feature: true'));
     });
   });
 
@@ -81,15 +82,15 @@ const config = {
       const file1 = await fs.readFile(path.join(targetDir, 'file1.js'), 'utf-8');
       const file2 = await fs.readFile(path.join(targetDir, 'file2.md'), 'utf-8');
 
-      expect(file1).to.equal('export const name = "test";');
-      expect(file2).to.equal('# Test Title');
+      assert.equal(file1, 'export const name = "test";');
+      assert.equal(file2, '# Test Title');
 
       // Non-template file should not be copied
       const nonTemplateExists = await fs
         .access(path.join(targetDir, 'non-template.js'))
         .then(() => true)
         .catch(() => false);
-      expect(nonTemplateExists).to.be.false;
+      assert.equal(nonTemplateExists, false);
     });
 
     it('should handle recursive directory copying', async function () {
@@ -109,8 +110,8 @@ const config = {
       const rootFile = await fs.readFile(path.join(targetDir, 'root.txt'), 'utf-8');
       const nestedFile = await fs.readFile(path.join(targetDir, 'subdir', 'nested.txt'), 'utf-8');
 
-      expect(rootFile).to.equal('root: test');
-      expect(nestedFile).to.equal('nested: test');
+      assert.equal(rootFile, 'root: test');
+      assert.equal(nestedFile, 'nested: test');
     });
 
     it('should handle empty directory', async function () {
@@ -126,7 +127,7 @@ const config = {
         .access(targetDir)
         .then(() => true)
         .catch(() => false);
-      expect(targetExists).to.be.false; // Target should not be created if no files to copy
+      assert.equal(targetExists, false); // Target should not be created if no files to copy
     });
   });
 });

--- a/test/validate-plugin.test.js
+++ b/test/validate-plugin.test.js
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import { strict as assert } from 'node:assert';
+import { describe, it, before, after } from 'node:test';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -26,9 +27,9 @@ describe('validate-plugin tool', function () {
       checks: ['structure', 'tests', 'docs', 'package-json']
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
     const text = result.content[0].text;
-    expect(text).to.include('Plugin meets quality standards');
+    assert.ok(text.includes('Plugin meets quality standards'));
   });
 
   it('should detect missing required files', async function () {
@@ -38,7 +39,7 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('Missing required');
+    assert.ok(text.includes('Missing required'));
   });
 
   it('should check test coverage', async function () {
@@ -48,7 +49,7 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('test');
+    assert.ok(text.includes('test'));
   });
 
   it('should validate package.json standards', async function () {
@@ -58,8 +59,8 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('package.json');
-    expect(text).to.include('follows convention');
+    assert.ok(text.includes('package.json'));
+    assert.ok(text.includes('follows convention'));
   });
 
   it('should handle non-existent plugin directory', async function () {
@@ -68,8 +69,8 @@ describe('validate-plugin tool', function () {
       checks: ['structure']
     });
 
-    expect(result.isError).to.be.true;
-    expect(result.content[0].text).to.include('Failed to validate');
+    assert.equal(result.isError, true);
+    assert.ok(result.content[0].text.includes('Failed to validate'));
   });
 
   it('should check ESLint configuration', async function () {
@@ -79,8 +80,8 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('ESLint configuration found');
-    expect(text).to.include('modern ESLint flat config');
+    assert.ok(text.includes('ESLint configuration found'));
+    assert.ok(text.includes('modern ESLint flat config'));
   });
 
   it('should handle missing ESLint configuration', async function () {
@@ -90,7 +91,7 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('Consider adding ESLint configuration');
+    assert.ok(text.includes('Consider adding ESLint configuration'));
   });
 
   it('should check coverage reports when available', async function () {
@@ -112,8 +113,8 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('Coverage reports found');
-    expect(text).to.include('95.5%');
+    assert.ok(text.includes('Coverage reports found'));
+    assert.ok(text.includes('95.5%'));
   });
 
   it('should handle all check types in one validation', async function () {
@@ -122,10 +123,10 @@ describe('validate-plugin tool', function () {
       checks: ['structure', 'tests', 'docs', 'package-json', 'eslint', 'coverage']
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
     const text = result.content[0].text;
-    expect(text).to.include('Quality score');
-    expect(text).to.include('Passed');
+    assert.ok(text.includes('Quality score'));
+    assert.ok(text.includes('Passed'));
   });
 
   it('should provide quality score and summary', async function () {
@@ -135,9 +136,9 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('Quality score:');
-    expect(text).to.include('%');
-    expect(text).to.include('Total checks:');
+    assert.ok(text.includes('Quality score:'));
+    assert.ok(text.includes('%'));
+    assert.ok(text.includes('Total checks:'));
   });
 
   it('should handle plugins with missing recommended directories', async function () {
@@ -147,7 +148,7 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('Consider adding directory');
+    assert.ok(text.includes('Consider adding directory'));
   });
 
   it('should validate package.json name convention', async function () {
@@ -157,7 +158,7 @@ describe('validate-plugin tool', function () {
     });
 
     const text = result.content[0].text;
-    expect(text).to.include('Plugin name follows convention');
+    assert.ok(text.includes('Plugin name follows convention'));
   });
 
   describe('Performance validation', function () {
@@ -177,9 +178,9 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Proper files object iteration detected');
-      expect(text).to.include('RegExp patterns appear optimally placed');
-      expect(text).to.include('Efficient Buffer handling');
+      assert.ok(text.includes('Proper files object iteration detected'));
+      assert.ok(text.includes('RegExp patterns appear optimally placed'));
+      assert.ok(text.includes('Efficient Buffer handling'));
     });
 
     it('should detect performance issues', async function () {
@@ -197,9 +198,9 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Pre-compile RegExp patterns outside loops');
-      expect(text).to.include('Use Buffer methods instead of string concatenation');
-      expect(text).to.include('Avoid cloning the entire files object');
+      assert.ok(text.includes('Pre-compile RegExp patterns outside loops'));
+      assert.ok(text.includes('Use Buffer methods instead of string concatenation'));
+      assert.ok(text.includes('Avoid cloning the entire files object'));
     });
 
     it('should validate async plugin patterns', async function () {
@@ -215,7 +216,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Proper async plugin pattern with done() callback');
+      assert.ok(text.includes('Proper async plugin pattern with done() callback'));
     });
   });
 
@@ -234,9 +235,9 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('eval() usage detected');
-      expect(text).to.include('Shell execution without input validation');
-      expect(text).to.include('Hardcoded secrets detected');
+      assert.ok(text.includes('eval() usage detected'));
+      assert.ok(text.includes('Shell execution without input validation'));
+      assert.ok(text.includes('Hardcoded secrets detected'));
     });
 
     it('should validate secure patterns', async function () {
@@ -253,9 +254,9 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Error handling detected');
-      expect(text).to.include('File content validation detected');
-      expect(text).to.include('Security audit script defined');
+      assert.ok(text.includes('Error handling detected'));
+      assert.ok(text.includes('File content validation detected'));
+      assert.ok(text.includes('Security audit script defined'));
     });
 
     it('should check dependency security', async function () {
@@ -271,8 +272,8 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Some dependencies use pinned versions');
-      expect(text).to.include('Security audit script defined');
+      assert.ok(text.includes('Some dependencies use pinned versions'));
+      assert.ok(text.includes('Security audit script defined'));
     });
   });
 
@@ -292,10 +293,10 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Proper two-phase plugin factory pattern detected');
-      expect(text).to.include('Correct Metalsmith plugin function signature detected');
-      expect(text).to.include('Plugin properly interacts with files object');
-      expect(text).to.include('Plugin works with file metadata');
+      assert.ok(text.includes('Proper two-phase plugin factory pattern detected'));
+      assert.ok(text.includes('Correct Metalsmith plugin function signature detected'));
+      assert.ok(text.includes('Plugin properly interacts with files object'));
+      assert.ok(text.includes('Plugin works with file metadata'));
     });
 
     it('should detect plugin pattern issues', async function () {
@@ -312,8 +313,8 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Consider using factory pattern');
-      expect(text).to.include('Plugin should interact with the files object');
+      assert.ok(text.includes('Consider using factory pattern'));
+      assert.ok(text.includes('Plugin should interact with the files object'));
     });
 
     it('should validate content processing patterns', async function () {
@@ -331,9 +332,9 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Proper Buffer validation for file.contents');
-      expect(text).to.include('Plugin filters files by type/pattern');
-      expect(text).to.include('Plugin handles options properly');
+      assert.ok(text.includes('Proper Buffer validation for file.contents'));
+      assert.ok(text.includes('Plugin filters files by type/pattern'));
+      assert.ok(text.includes('Plugin handles options properly'));
     });
   });
 
@@ -343,10 +344,10 @@ describe('validate-plugin tool', function () {
       checks: ['structure', 'tests', 'docs', 'package-json', 'performance', 'security', 'metalsmith-patterns']
     });
 
-    expect(result.isError).to.not.be.true;
+    assert.notEqual(result.isError, true);
     const text = result.content[0].text;
-    expect(text).to.include('Quality score');
-    expect(text).to.include('Plugin meets quality standards');
+    assert.ok(text.includes('Quality score'));
+    assert.ok(text.includes('Plugin meets quality standards'));
   });
 
   describe('Edge cases and error handling', function () {
@@ -364,8 +365,8 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('JSDoc @typedef for Options found');
-      expect(text).to.include('Main export function has JSDoc documentation');
+      assert.ok(text.includes('JSDoc @typedef for Options found'));
+      assert.ok(text.includes('Main export function has JSDoc documentation'));
     });
 
     it('should handle integration validation', async function () {
@@ -378,7 +379,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Plugin accesses global metadata');
+      assert.ok(text.includes('Plugin accesses global metadata'));
     });
 
     it('should handle functional validation mode', async function () {
@@ -388,9 +389,9 @@ describe('validate-plugin tool', function () {
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include('appropriate'); // Should include "complexity is appropriate"
+      assert.ok(text.includes('appropriate')); // Should include "complexity is appropriate"
     });
 
     it('should handle missing files gracefully in performance validation', async function () {
@@ -404,7 +405,7 @@ describe('validate-plugin tool', function () {
         checks: ['performance']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
     });
 
     it('should handle plugins with async operations but missing done callback', async function () {
@@ -420,7 +421,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('may cause build issues');
+      assert.ok(text.includes('may cause build issues'));
     });
 
     it('should validate security with environment variable logging', async function () {
@@ -435,7 +436,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Environment variables in logging');
+      assert.ok(text.includes('Environment variables in logging'));
     });
 
     it('should validate plugin function name setting', async function () {
@@ -450,7 +451,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Plugin function name set for debugging');
+      assert.ok(text.includes('Plugin function name set for debugging'));
     });
 
     it('should validate chainability patterns', async function () {
@@ -467,7 +468,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('return metalsmith instance');
+      assert.ok(text.includes('return metalsmith instance'));
     });
 
     it('should validate error propagation in async plugins', async function () {
@@ -484,7 +485,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Proper error propagation in async plugin');
+      assert.ok(text.includes('Proper error propagation in async plugin'));
     });
 
     it('should warn about missing error propagation', async function () {
@@ -501,7 +502,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('should propagate errors via done(err)');
+      assert.ok(text.includes('should propagate errors via done(err)'));
     });
 
     it('should handle validation errors gracefully', async function () {
@@ -519,7 +520,7 @@ describe('validate-plugin tool', function () {
         checks: ['metalsmith-patterns']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should handle errors gracefully
     });
 
@@ -537,9 +538,9 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Add default options handling');
-      expect(text).to.include('Set function name for better debugging');
-      expect(text).to.include('Consider using metalsmith.metadata()');
+      assert.ok(text.includes('Add default options handling'));
+      assert.ok(text.includes('Set function name for better debugging'));
+      assert.ok(text.includes('Consider using metalsmith.metadata()'));
     });
 
     it('should handle edge cases in checkStructure', async function () {
@@ -550,7 +551,7 @@ describe('validate-plugin tool', function () {
       });
 
       const text = result.content[0].text;
-      expect(text).to.include('Directory');
+      assert.ok(text.includes('Directory'));
     });
 
     it('should test functional mode complexities', async function () {
@@ -564,7 +565,7 @@ describe('validate-plugin tool', function () {
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
     });
 
     it('should test deepMerge function with custom validation config', async function () {
@@ -601,7 +602,7 @@ describe('validate-plugin tool', function () {
         checks: ['tests', 'docs']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // The deepMerge function should have been called to merge the custom config
       // Just check that the validation ran without errors - this will call deepMerge
     });
@@ -631,7 +632,7 @@ describe('validate-plugin tool', function () {
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // The runCommand function should have been called to run the test scripts
     });
 
@@ -660,7 +661,7 @@ describe('validate-plugin tool', function () {
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should handle command failures gracefully
     });
 
@@ -719,7 +720,7 @@ describe('validate-plugin tool', function () {
         checks: ['structure']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should analyze complexity correctly
     });
 
@@ -739,7 +740,7 @@ describe('validate-plugin tool', function () {
         checks: ['structure', 'tests', 'docs', 'eslint', 'jsdoc', 'performance', 'security']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should handle missing files gracefully across all check types
     });
 
@@ -761,9 +762,9 @@ describe('validate-plugin tool', function () {
         checks: ['structure']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include('Recommended file .release-it.json exists');
+      assert.ok(text.includes('Recommended file .release-it.json exists'));
     });
 
     it('should test runCommand with process exit codes', async function () {
@@ -791,7 +792,7 @@ describe('validate-plugin tool', function () {
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should handle different command exit codes
     });
 
@@ -821,7 +822,7 @@ describe('validate-plugin tool', function () {
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should handle stderr output gracefully
     });
 
@@ -874,7 +875,7 @@ describe('validate-plugin tool', function () {
         checks: ['structure']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should detect and report high complexity
     });
 
@@ -895,7 +896,7 @@ describe('validate-plugin tool', function () {
         checks: ['structure', 'performance', 'security', 'metalsmith-patterns']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should handle missing main file gracefully in all validation checks
     });
 
@@ -913,9 +914,9 @@ describe('validate-plugin tool', function () {
         checks: ['tests']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include('Test fixtures present');
+      assert.ok(text.includes('Test fixtures present'));
     });
 
     it('should test functional validation with coverage output', async function () {
@@ -943,9 +944,9 @@ describe('validate-plugin tool', function () {
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include('Coverage generated successfully');
+      assert.ok(text.includes('Coverage generated successfully'));
     });
 
     it('should test documentation with all required sections', async function () {
@@ -992,11 +993,11 @@ MIT
         checks: ['docs']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include('Installation');
-      expect(text).to.include('Usage');
-      expect(text).to.include('Options');
+      assert.ok(text.includes('Installation'));
+      assert.ok(text.includes('Usage'));
+      assert.ok(text.includes('Options'));
     });
 
     it('should test package.json with all recommended fields', async function () {
@@ -1042,9 +1043,9 @@ MIT
         checks: ['package-json']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include('Plugin name follows convention'); // Should validate the name
+      assert.ok(text.includes('Plugin name follows convention')); // Should validate the name
     });
 
     it('should test all validation with comprehensive plugin', async function () {
@@ -1153,7 +1154,7 @@ MIT
         functional: true // Test all checks in functional mode
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // This comprehensive test should trigger many of the uncovered code paths
     });
 
@@ -1167,7 +1168,7 @@ MIT
         functional: false // Explicitly test non-functional mode
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should check recommended directories in traditional mode
     });
 
@@ -1183,9 +1184,9 @@ MIT
         checks: ['structure']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include('Consider adding'); // Should have recommendations
+      assert.ok(text.includes('Consider adding')); // Should have recommendations
     });
 
     it('should test runCommand spawn error handling', async function () {
@@ -1213,7 +1214,7 @@ MIT
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should handle spawn errors gracefully
     });
 
@@ -1266,7 +1267,7 @@ MIT
         functional: true
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should analyze complexity and hit edge case paths
     });
 
@@ -1281,7 +1282,7 @@ MIT
         functional: false // Use non-functional mode to trigger different paths
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       // Should test various error handling paths
     });
 
@@ -1303,9 +1304,9 @@ MIT
         checks: ['release-notes']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include('✓ Release-it configured with GitHub auto-generated release notes');
+      assert.ok(text.includes('✓ Release-it configured with GitHub auto-generated release notes'));
     });
 
     it('should detect missing autoGenerate configuration', async function () {
@@ -1325,10 +1326,10 @@ MIT
         checks: ['release-notes']
       });
 
-      expect(result.isError).to.not.be.true;
+      assert.notEqual(result.isError, true);
       const text = result.content[0].text;
-      expect(text).to.include(
-        '💡 Consider setting github.autoGenerate to true in .release-it.json for automatic release notes'
+      assert.ok(
+        text.includes('💡 Consider setting github.autoGenerate to true in .release-it.json for automatic release notes')
       );
     });
   });
@@ -1431,7 +1432,7 @@ import plugin from '../src/index.js';
 
 describe('plugin', () => {
   it('should export a function', () => {
-    expect(plugin).to.be.a('function');
+    assert.equal(typeof plugin, 'function');
   });
 });`
   );


### PR DESCRIPTION
## Summary
- Switch from mocha + chai + c8 to Node 22's built-in test runner
- Convert all `expect(...).to.*` assertions to `node:assert/strict`
- Drop `mocha`, `chai`, `c8` from devDependencies (3 fewer transitive trees)
- Coverage now uses `node --experimental-test-coverage --test-reporter=lcov` — same LH:/LF: format as c8, so the CI badge step is unchanged

## Test plan
- [x] All 147 tests pass on Node 22
- [x] `npm test` works
- [x] `npm run coverage` produces `coverage/lcov.info` in compatible format
- [x] Biome lint passes
- [ ] CI green on Node 22.x and 24.x